### PR TITLE
Balance Mining Rates and Station Prices

### DIFF
--- a/game/common/asteroid_field_types.py
+++ b/game/common/asteroid_field_types.py
@@ -36,7 +36,7 @@ class GoldField(AsteroidField):
                 name="Gold Field",
                 position=position,
                 material_type=MaterialType.gold,
-                mining_rate=0.8)
+                mining_rate=0.4)
 
 class GeothiteField(AsteroidField):
     def init(self, position):
@@ -45,7 +45,7 @@ class GeothiteField(AsteroidField):
                 name="Geothite Field",
                 position=position,
                 material_type=MaterialType.goethite,
-                mining_rate=1.0)
+                mining_rate=0.55)
 
 class CuperiteField(AsteroidField):
     def init(self, position):
@@ -54,4 +54,4 @@ class CuperiteField(AsteroidField):
                 name="Cuprite Field",
                 position=position,
                 material_type=MaterialType.cuprite,
-                mining_rate=1.2)
+                mining_rate=0.7)

--- a/game/common/illegal_salvage.py
+++ b/game/common/illegal_salvage.py
@@ -13,7 +13,7 @@ class IllegalSalvage(GameObject):
 
         self.position = position
         self.material_type = MaterialType.salvage
-        self.turns_till_recycling = 100
+        self.turns_till_recycling = 150
         self.amount = amount
 
     def to_dict(self, security_level=SecurityLevel.other_player):

--- a/game/common/npc/test/test_priority_trader_npc.py
+++ b/game/common/npc/test/test_priority_trader_npc.py
@@ -8,7 +8,7 @@ from game.config import *
 from game.utils.helpers import *
 
 class TestPriorityTraderNPC(NPC):
-
+    # NPC that will take the top 3 current most profitable materials, select one, then go buy as much of it as possible and go to sell it
     def __init__(self, ship):
         UserClient.__init__(self)
         self.ship = ship

--- a/game/common/npc/test/test_trader_npc.py
+++ b/game/common/npc/test/test_trader_npc.py
@@ -8,7 +8,7 @@ from game.config import *
 from game.utils.helpers import *
 
 class TestTraderNPC(NPC):
-
+    # NPC will choose a random trade material, buy as much of it as possible, then go to sell it
     def __init__(self, ship):
         UserClient.__init__(self)
         self.ship = ship
@@ -101,14 +101,12 @@ class TestTraderNPC(NPC):
                         chosenSellStation = tempStation
                         sell = True
                         break
-                if sell == True:
+                if sell is True:
                     for tempStation in stations:
                         if tempStation.production_material == chosenMaterial:
                             chosenBuyStation = tempStation
                             done = True
                             break
-                else:
-                    continue
 
             # done = False
             # trade_materials = [MaterialType.iron, MaterialType.steel, MaterialType.circuitry, MaterialType.computers, MaterialType.weaponry, MaterialType.copper]

--- a/game/server/buy_sell_controller.py
+++ b/game/server/buy_sell_controller.py
@@ -170,7 +170,7 @@ class BuySellController:
         self.print("STATION PRIMARY:  " + str(station.primary_import) + "    "+ str(station.cargo[station.primary_import]))
 
         # verify station has enough material, reducing requested quantity to what the station has.
-        quantity = min(station.production_qty, quantity)
+        quantity = min(station.cargo[material], quantity)
 
         # verify that the ship has enough credits for the requested materials, otherwise reduce order
         # to what the ship can afford

--- a/game/universe_config.py
+++ b/game/universe_config.py
@@ -4,6 +4,7 @@ from game.config import *
 from game.common.enums import *
 from game.utils.projection import *
 
+frequency_addition = 10
 STATION_DEFINITIONS = [
     {
         #s6 Copper
@@ -12,29 +13,29 @@ STATION_DEFINITIONS = [
         "position": percent_world(0.05, 0.9),
 
         "primary_import": MaterialType.cuprite,
-        "primary_consumption_qty": 50,
-        "primary_max": 2000,
+        "primary_consumption_qty": 80,
+        "primary_max": 1250,
 
         "secondary_import": MaterialType.drones,
-        "secondary_consumption_qty": 1,
-        "secondary_max": 500,
+        "secondary_consumption_qty": 10,
+        "secondary_max": 200,
 
         "production_material": MaterialType.copper,
-        "production_frequency": 1,
-        "production_qty": 10,
-        "production_max": 15000,
+        "production_frequency": frequency_addition + 20,
+        "production_qty": 35,
+        "production_max": 1000,
 
-        "sell_price": 85,
-        "primary_buy_price": 30,
-        "secondary_buy_price": 45,
+        "sell_price": 16,
+        "primary_buy_price": 7,
+        "secondary_buy_price": 56,
 
-        "base_sell_price": 85,
-        "base_primary_buy_price": 30,
-        "base_secondary_buy_price": 45,
+        "base_sell_price": 16,
+        "base_primary_buy_price": 7,
+        "base_secondary_buy_price": 56,
 
 
         "cargo": {
-            MaterialType.cuprite: 20,
+            MaterialType.cuprite: 500,
             MaterialType.drones: 10,
             MaterialType.copper: 0
         }
@@ -46,28 +47,28 @@ STATION_DEFINITIONS = [
         "position": percent_world(0.025, 0.6),
 
         "primary_import": MaterialType.circuitry,
-        "primary_consumption_qty": 2,
-        "primary_max": 600,
+        "primary_consumption_qty": 20,
+        "primary_max": 300,
 
         "secondary_import": MaterialType.null,
         "secondary_consumption_qty": 0,
         "secondary_max": 0,
 
         "production_material": MaterialType.pylons,
-        "production_frequency": 1,
-        "production_qty": 5,
-        "production_max": 4500,
+        "production_frequency": frequency_addition + 27,
+        "production_qty": 50,
+        "production_max": 500,
 
-        "sell_price": 150,
-        "primary_buy_price": 250,
+        "sell_price": 15,
+        "primary_buy_price": 25,
         "secondary_buy_price": 0,
 
-        "base_sell_price": 150,
-        "base_primary_buy_price": 250,
+        "base_sell_price": 15,
+        "base_primary_buy_price": 25,
         "base_secondary_buy_price": 0,
 
         "cargo": {
-            MaterialType.circuitry: 100,
+            MaterialType.circuitry: 80,
             MaterialType.pylons: 10,
         }
     },
@@ -78,29 +79,29 @@ STATION_DEFINITIONS = [
         "position": percent_world(0.15, 0.58),
 
         "primary_import": MaterialType.computers,
-        "primary_consumption_qty": 2,
-        "primary_max": 600,
+        "primary_consumption_qty": 20,
+        "primary_max": 300,
 
         "secondary_import": MaterialType.null,
         "secondary_consumption_qty": 0,
         "secondary_max": 0,
 
         "production_material": MaterialType.weaponry,
-        "production_frequency": 1,
-        "production_qty": 2,
-        "production_max": 5500,
+        "production_frequency": frequency_addition + 15,
+        "production_qty": 20,
+        "production_max": 260,
 
-        "sell_price": 650,
-        "primary_buy_price": 300,
+        "sell_price": 42,
+        "primary_buy_price": 30,
         "secondary_buy_price": 0,
 
-        "base_sell_price": 650,
-        "base_primary_buy_price": 300,
+        "base_sell_price": 42,
+        "base_primary_buy_price": 30,
         "base_secondary_buy_price": 0,
 
         "cargo": {
             MaterialType.computers: 50,
-            MaterialType.weaponry: 0
+            MaterialType.weaponry: 10
         }
     },
     {
@@ -110,29 +111,29 @@ STATION_DEFINITIONS = [
         "position": percent_world(0.085, 0.40),
 
         "primary_import": MaterialType.steel,
-        "primary_consumption_qty": 4,
-        "primary_max": 800,
+        "primary_consumption_qty": 40,
+        "primary_max": 500,
 
         "secondary_import": MaterialType.pylons,
-        "secondary_consumption_qty": 1,
-        "secondary_max": 1000,
+        "secondary_consumption_qty": 30,
+        "secondary_max": 500,
 
         "production_material": MaterialType.machinery,
-        "production_frequency": 1,
-        "production_qty": 4,
-        "production_max": 10000,
+        "production_frequency": frequency_addition + 23,
+        "production_qty": 40,
+        "production_max": 400,
 
-        "sell_price": 200,
-        "primary_buy_price": 240,
-        "secondary_buy_price": 370,
+        "sell_price": 20,
+        "primary_buy_price": 24,
+        "secondary_buy_price": 20,
 
-        "base_sell_price": 200,
-        "base_primary_buy_price": 240,
-        "base_secondary_buy_price": 370,
+        "base_sell_price": 20,
+        "base_primary_buy_price": 24,
+        "base_secondary_buy_price": 20,
 
         "cargo": {
             MaterialType.steel: 56,
-            MaterialType.pylons: 100,
+            MaterialType.pylons: 70,
             MaterialType.machinery: 0
         }
     },
@@ -143,28 +144,28 @@ STATION_DEFINITIONS = [
         "position": percent_world(0.4, 0.10),
 
         "primary_import": MaterialType.copper,
-        "primary_consumption_qty": 6,
-        "primary_max": 1000,
+        "primary_consumption_qty": 42,
+        "primary_max": 800,
 
         "secondary_import": MaterialType.null,
         "secondary_consumption_qty": 0,
         "secondary_max": 0,
 
         "production_material": MaterialType.wire,
-        "production_frequency": 1,
-        "production_qty": 15,
-        "production_max": 10000,
+        "production_frequency": frequency_addition + 18,
+        "production_qty": 38,
+        "production_max": 900,
 
-        "sell_price": 100,
-        "primary_buy_price": 130,
-        "secondary_buy_price": 100,
+        "sell_price": 10,
+        "primary_buy_price": 19,
+        "secondary_buy_price": 10,
 
-        "base_sell_price": 100,
-        "base_primary_buy_price": 130,
-        "base_secondary_buy_price": 100,
+        "base_sell_price": 10,
+        "base_primary_buy_price": 19,
+        "base_secondary_buy_price": 10,
 
         "cargo": {
-            MaterialType.copper: 23,
+            MaterialType.copper: 50,
             MaterialType.wire: 0
         }
     },
@@ -176,27 +177,27 @@ STATION_DEFINITIONS = [
 
         "primary_import": MaterialType.goethite,
         "primary_consumption_qty": 55,
-        "primary_max": 1800,
+        "primary_max": 1200,
 
         "secondary_import": MaterialType.machinery,
-        "secondary_consumption_qty": 1,
-        "secondary_max": 1400,
+        "secondary_consumption_qty": 10,
+        "secondary_max": 200,
 
         "production_material": MaterialType.iron,
-        "production_frequency": 1,
-        "production_qty": 10,
-        "production_max": 15000,
+        "production_frequency": frequency_addition + 22,
+        "production_qty": 40,
+        "production_max": 800,
 
-        "sell_price": 122,
-        "primary_buy_price": 25,
-        "secondary_buy_price": 30,
+        "sell_price": 12,
+        "primary_buy_price": 5,
+        "secondary_buy_price": 21,
 
-        "base_sell_price": 122,
-        "base_primary_buy_price": 25,
-        "base_secondary_buy_price": 30,
+        "base_sell_price": 12,
+        "base_primary_buy_price": 5,
+        "base_secondary_buy_price": 21,
 
         "cargo": {
-            MaterialType.goethite: 75,
+            MaterialType.goethite: 700,
             MaterialType.machinery: 0,
             MaterialType.iron: 0
         }
@@ -208,7 +209,7 @@ STATION_DEFINITIONS = [
         "position": percent_world(0.63, 0.08),
 
         "primary_import": MaterialType.circuitry,
-        "primary_consumption_qty": 3,
+        "primary_consumption_qty": 30,
         "primary_max": 700,
 
         "secondary_import": MaterialType.null,
@@ -216,21 +217,21 @@ STATION_DEFINITIONS = [
         "secondary_max": 0,
 
         "production_material": MaterialType.computers,
-        "production_frequency": 1,
-        "production_qty": 7,
-        "production_max": 10000,
+        "production_frequency": frequency_addition + 30,
+        "production_qty": 50,
+        "production_max": 400,
 
-        "sell_price": 266,
-        "primary_buy_price": 350,
-        "secondary_buy_price": 100,
+        "sell_price": 26,
+        "primary_buy_price": 31,
+        "secondary_buy_price": 10,
 
-        "base_sell_price": 266,
-        "base_primary_buy_price": 350,
-        "base_secondary_buy_price": 100,
+        "base_sell_price": 26,
+        "base_primary_buy_price": 31,
+        "base_secondary_buy_price": 10,
 
         "cargo": {
             MaterialType.circuitry: 75,
-            MaterialType.computers: 0
+            MaterialType.computers: 20
         }
     },
     {
@@ -241,27 +242,27 @@ STATION_DEFINITIONS = [
 
         "primary_import": MaterialType.gold,
         "primary_consumption_qty": 70,
-        "primary_max": 3000,
+        "primary_max": 1500,
 
         "secondary_import": MaterialType.wire,
-        "secondary_consumption_qty": 1,
-        "secondary_max": 1000,
+        "secondary_consumption_qty": 30,
+        "secondary_max": 420,
 
         "production_material": MaterialType.circuitry,
-        "production_frequency": 1,
-        "production_qty": 3,
-        "production_max": 10000,
+        "production_frequency": frequency_addition + 30,
+        "production_qty": 30,
+        "production_max": 450,
 
-        "sell_price": 237,
-        "primary_buy_price": 40,
-        "secondary_buy_price": 100,
+        "sell_price": 23,
+        "primary_buy_price": 10,
+        "secondary_buy_price": 12,
 
-        "base_sell_price": 237,
-        "base_primary_buy_price": 40,
-        "base_secondary_buy_price": 100,
+        "base_sell_price": 23,
+        "base_primary_buy_price": 10,
+        "base_secondary_buy_price": 12,
 
         "cargo": {
-            MaterialType.gold: 75,
+            MaterialType.gold: 350,
             MaterialType.wire: 75,
             MaterialType.circuitry: 0
         }
@@ -273,28 +274,28 @@ STATION_DEFINITIONS = [
         "position": percent_world(0.96, 0.95),
 
         "primary_import": MaterialType.weaponry,
-        "primary_consumption_qty": 1,
-        "primary_max": 300,
+        "primary_consumption_qty": 10,
+        "primary_max": 200,
 
         "secondary_import": MaterialType.null,
         "secondary_consumption_qty": 0,
         "secondary_max": 0,
 
         "production_material": MaterialType.drones,
-        "production_frequency": 1,
-        "production_qty": 1,
-        "production_max": 10000,
+        "production_frequency": frequency_addition + 23,
+        "production_qty": 30,
+        "production_max": 240,
 
-        "sell_price": 900,
-        "primary_buy_price": 800,
-        "secondary_buy_price": 100,
+        "sell_price": 49,
+        "primary_buy_price": 45,
+        "secondary_buy_price": 10,
 
-        "base_sell_price": 900,
-        "base_primary_buy_price": 800,
-        "base_secondary_buy_price": 100,
+        "base_sell_price": 49,
+        "base_primary_buy_price": 45,
+        "base_secondary_buy_price": 10,
 
         "cargo": {
-            MaterialType.weaponry: 15,
+            MaterialType.weaponry: 30,
             MaterialType.drones: 0
         }
     },
@@ -305,25 +306,25 @@ STATION_DEFINITIONS = [
         "position": percent_world(0.92, 0.03),
 
         "primary_import": MaterialType.iron,
-        "primary_consumption_qty": 5,
+        "primary_consumption_qty": 50,
         "primary_max": 900,
 
         "secondary_import": MaterialType.drones,
-        "secondary_consumption_qty": 1,
-        "secondary_max": 1000,
+        "secondary_consumption_qty": 10,
+        "secondary_max": 100,
 
         "production_material": MaterialType.steel,
-        "production_frequency": 1,
-        "production_qty": 5,
-        "production_max": 10000,
+        "production_frequency": frequency_addition + 21,
+        "production_qty": 70,
+        "production_max": 630,
 
-        "sell_price": 180,
-        "primary_buy_price": 150,
-        "secondary_buy_price": 100,
+        "sell_price": 18,
+        "primary_buy_price": 15,
+        "secondary_buy_price": 54,
 
-        "base_sell_price": 180,
-        "base_primary_buy_price": 150,
-        "base_secondary_buy_price": 100,
+        "base_sell_price": 18,
+        "base_primary_buy_price": 15,
+        "base_secondary_buy_price": 54,
 
         "cargo": {
             MaterialType.iron: 100,


### PR DESCRIPTION
#135 #136 The mining was highly balanced through the station prices and didn't have many changes to what existed. The prices at stations change based off of how many of the material it has for the respective price. If the station has a lot of a primary or secondary material then the buy price will go down since they aren't looking for the material. Same thing with the production price, if it has a lot of the production material the sell price of it will go down. The prices also have a min and max value. The max is dynamic based off of how much of the material it has, the min is based of the min_value_ratio variable in the station_controller and is multiplied by the base price of that material. Otherwise there were a lot of value changes in the universe_config for the raw values of stations.