### PR TITLE
Graph fixes

### DIFF
--- a/game/common/station.py
+++ b/game/common/station.py
@@ -162,11 +162,11 @@ class Station(GameObject):
 
             self.sell_price = data["sell_price"]
             self.primary_buy_price = data["primary_buy_price"]
-            self.secondary_buy_price = data["primary_buy_price"]
+            self.secondary_buy_price = data["secondary_buy_price"]
 
             self.base_sell_price = data["base_sell_price"]
             self.base_primary_buy_price = data["base_primary_buy_price"]
-            self.base_secondary_buy_price = data["base_primary_buy_price"]
+            self.base_secondary_buy_price = data["base_secondary_buy_price"]
 
 
 class BlackMarketStation(Station):

--- a/game/server/station_controller.py
+++ b/game/server/station_controller.py
@@ -90,7 +90,7 @@ class StationController:
 
             if sufficient_primary_in_cargo and consume_inputs and not_at_max_production:
                 station.cargo[station.primary_import] -= station.primary_consumption_qty
-                self.station_data[station_id]["primary_consumed"] += station.primary_consumption_qty
+                self.station_data[station_id]["primary_consumed"] = station.primary_consumption_qty
 
                 if(has_secondary and
                     sufficient_secondary_in_cargo and
@@ -99,7 +99,6 @@ class StationController:
                     station.cargo[station.secondary_import] -= station.secondary_consumption_qty
 
                     qty = station.production_qty * 2
-                    prev_cargo = None
                     if station.production_material not in station.cargo:
                         station.cargo[station.production_material] = qty
                     else:
@@ -107,20 +106,21 @@ class StationController:
                         qty = min(qty, station.production_max - prev_cargo)
                         station.cargo[station.production_material] += qty
 
-                    self.station_data[station_id]["production_produced"] += qty
+                    self.station_data[station_id]["production_produced"] = qty
 
                     self.print(f"Created x{station.production_qty}*2 material {station.production_material}")
-                    self.station_data[station_id]["secondary_consumed"] += station.secondary_consumption_qty
+                    self.station_data[station_id]["secondary_consumed"] = station.secondary_consumption_qty
 
                 else:
                     qty = station.production_qty
                     if station.production_material not in station.cargo:
                         station.cargo[station.production_material] = qty
                     else:
-                        qty = min(station.cargo[station.production_material] + qty, station.production_max)
-                        station.cargo[station.production_material] = qty
+                        prev_cargo = station.cargo[station.production_material]
+                        qty = min(qty, station.production_max - prev_cargo)
+                        station.cargo[station.production_material] += qty
 
-                    self.station_data[station_id]["production_produced"] += qty
+                    self.station_data[station_id]["production_produced"] = qty
 
                     self.print(f"Created x{station.production_qty} material {station.production_material}")
 


### PR DESCRIPTION
-Properly displays the material produced and consumed graphs by only
showing what was produced that turn and not being added to previous
values.
-Fixed the secondary_buy_price graph lines closes #163